### PR TITLE
Require dask and numpy

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -9,3 +9,5 @@ dependencies:
   - coverage==4.0.3
   - python-coveralls==2.7.0
   - pytest==3.0.5
+  - dask==0.13.0
+  - numpy==1.11.3

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -7,3 +7,5 @@ dependencies:
   - pip==9.0.1
   - wheel==0.29.0
   - Sphinx==1.5.1
+  - dask==0.13.0
+  - numpy==1.11.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    # TODO: put package requirements here
+    "dask",
+    "numpy",
 ]
 
 test_requirements = [


### PR DESCRIPTION
As this library will need both dask and numpy for the operations it provides, go ahead and add them as requirements for the package, CI, and building the docs.