### PR TITLE
Add utils and bool comparison function

### DIFF
--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -1,0 +1,31 @@
+import dask
+import dask.array
+
+import dask_distance._compat
+
+
+def _bool_cmp_mtx_cnt(u, v):
+    u = dask_distance._compat._asarray(u)
+    v = dask_distance._compat._asarray(v)
+
+    u_1 = u.astype(bool)
+    v_1 = v.astype(bool)
+    u_0 = ~u_1
+    v_0 = ~v_1
+
+    uv_11 = u_1 & v_1
+    uv_10 = u_1 & v_0
+    uv_01 = u_0 & v_1
+    uv_00 = u_0 & v_0
+
+    uv_11_sum = uv_11.sum(axis=0, dtype=float)
+    uv_10_sum = uv_10.sum(axis=0, dtype=float)
+    uv_01_sum = uv_01.sum(axis=0, dtype=float)
+    uv_00_sum = uv_00.sum(axis=0, dtype=float)
+
+    uv_cmp_mtx_cnts = dask.array.stack([
+        dask.array.stack([uv_00_sum, uv_01_sum]),
+        dask.array.stack([uv_10_sum, uv_11_sum]),
+    ])
+
+    return uv_cmp_mtx_cnts

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+from __future__ import absolute_import
+
+import pytest
+
+import numpy as np
+
+import dask_distance._utils
+
+
+def test_import_toplevel():
+    u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=bool)
+    v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=bool)
+
+    uv_cmp_mtx = dask_distance._utils._bool_cmp_mtx_cnt(u, v)
+
+    uv_cmp_mtx_exp = np.array([[1, 2], [3, 4]], dtype=float)
+
+    assert (np.array(uv_cmp_mtx) == uv_cmp_mtx_exp).all()


### PR DESCRIPTION
Creates stubs for `dask_distance._utils` and ` tests.test__utils` to hold various internal utility functions.

Also adds a utility function for counting up the number of different `True`/`False` combinations between two 1-D `bool` arrays. This will be useful for a variety of distance metrics on `bool` arrays.