### PR TITLE
Use relative imports in package

### DIFF
--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -1,12 +1,12 @@
 import dask
 import dask.array
 
-import dask_distance._compat
+from . import _compat
 
 
 def _bool_cmp_mtx_cnt(u, v):
-    u = dask_distance._compat._asarray(u)
-    v = dask_distance._compat._asarray(v)
+    u = _compat._asarray(u)
+    v = _compat._asarray(v)
 
     u_1 = u.astype(bool)
     v_1 = v.astype(bool)


### PR DESCRIPTION
Instead of importing the package from a potentially different location, make sure to use relative imports.