### PR TITLE
Require scipy for testing

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -11,3 +11,4 @@ dependencies:
   - pytest==3.0.5
   - dask==0.13.0
   - numpy==1.11.3
+  - scipy==0.19.1

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ requirements = [
 
 test_requirements = [
     "pytest",
+    "scipy",
 ]
 
 cmdclasses = {


### PR DESCRIPTION
As we will need to compare our result against known, working functions from SciPy, go ahead and require SciPy as a test requirement. Since SciPy is not actually needed at run time for anything we are going to add, we don't make SciPy a run time dependency.