### PR TITLE
Add dice

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -1,8 +1,43 @@
 # -*- coding: utf-8 -*-
 
+
+from __future__ import division
+
+
 __author__ = """John Kirkham"""
 __email__ = "kirkhamj@janelia.hhmi.org"
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+from . import _utils
+
+
+def dice(u, v):
+    """
+    Finds the Dice dissimilarity between two 1-D bool arrays.
+
+    .. math::
+
+       \\frac{ c_{TF} + c_{FT} }{ 2 \cdot c_{TT} + c_{FT} + c_{TF} }
+
+    where :math:`c_{XY} = \sum_{i} \delta_{u_{i} X} \delta_{v_{i} Y}`
+
+    Args:
+        u:           1-D bool array
+        v:           1-D bool array
+
+    Returns:
+        float:       Dice dissimilarity.
+    """
+
+    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+
+    result = (
+        (uv_mtx[1, 0] + uv_mtx[0, 1]) /
+        (2 * uv_mtx[1, 1] + uv_mtx[1, 0] + uv_mtx[0, 1])
+    )
+
+    return result

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -3,11 +3,46 @@
 
 from __future__ import absolute_import
 
+import numpy as np
+import scipy.spatial.distance as spdist
+
+import dask.array as da
+
 import pytest
 
+import dask_distance
 
-def test_import_toplevel():
-    try:
-        import dask_distance
-    except ImportError:
-        pytest.fail("Unable to import `dask_distance`.")
+
+@pytest.mark.parametrize(
+    "funcname", [
+        "dice",
+    ]
+)
+@pytest.mark.parametrize(
+    "seed", [
+        0,
+        137,
+        34,
+    ]
+)
+@pytest.mark.parametrize(
+    "size, chunks", [
+        (10, 5),
+    ]
+)
+def test_1d_bool_dist(funcname, seed, size, chunks):
+    np.random.seed(seed)
+
+    a_u = np.random.randint(0, 2, (size,), dtype=bool)
+    a_v = np.random.randint(0, 2, (size,), dtype=bool)
+
+    d_u = da.from_array(a_u, chunks=chunks)
+    d_v = da.from_array(a_v, chunks=chunks)
+
+    sp_func = getattr(spdist, funcname)
+    da_func = getattr(dask_distance, funcname)
+
+    a_r = sp_func(a_u, a_v)
+    d_r = da_func(d_u, d_v)
+
+    assert np.array(d_r) == a_r


### PR DESCRIPTION
Implements a function for computing the Dice dissimilarity of two 1-D `bool` arrays with Dask. Works similarly to the SciPy function of the same name.