### PR TITLE
Sum all comparisons in hamming

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -64,8 +64,7 @@ def hamming(u, v):
     uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
 
     result = (
-        (uv_mtx[1, 0] + uv_mtx[0, 1]) /
-        float(len(u))
+        (uv_mtx[1, 0] + uv_mtx[0, 1]) / (uv_mtx.sum())
     )
 
     return result


### PR DESCRIPTION
Instead of relying on the length of the 1-D bool array provided to `hamming`, which may be unknown in some cases, simply sum all comparisons to find the number of elements.