### PR TITLE
Add kulsinski

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -96,3 +96,32 @@ def jaccard(u, v):
     )
 
     return result
+
+
+def kulsinski(u, v):
+    """
+    Finds the Kulsinski dissimilarity between two 1-D bool arrays.
+
+    .. math::
+
+       \\frac{ 2 \cdot \left(c_{TF} + c_{FT}\\right) + c_{FF} }
+             { c_{TT} + 2 \cdot \left(c_{TF} + c_{FT}\\right) + c_{FF} }
+
+    where :math:`c_{XY} = \sum_{i} \delta_{u_{i} X} \delta_{v_{i} Y}`
+
+    Args:
+        u:           1-D bool array
+        v:           1-D bool array
+
+    Returns:
+        float:       Kulsinski dissimilarity
+    """
+
+    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+
+    result = (
+        (2 * (uv_mtx[1, 0] + uv_mtx[0, 1]) + uv_mtx[0, 0]) /
+        (uv_mtx[1, 1] + 2 * (uv_mtx[1, 0] + uv_mtx[0, 1]) + uv_mtx[0, 0])
+    )
+
+    return result

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -18,6 +18,7 @@ import dask_distance
         "dice",
         "hamming",
         "jaccard",
+        "kulsinski",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a function for computing the Kulsinski dissimilarity of two 1-D bool arrays with Dask. Also tests it by comparing to the SciPy implementation of the same name.