### PR TITLE
Add sokalsneath

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -224,3 +224,34 @@ def sokalmichener(u, v):
     )
 
     return result
+
+
+def sokalsneath(u, v):
+    """
+    Finds the Sokal-Sneath dissimilarity between two 1-D bool arrays.
+
+    .. math::
+
+       \\frac{ 2 \cdot \left(c_{TF} + c_{FT}\\right) }
+             { c_{TT} + 2 \cdot \left(c_{TF} + c_{FT}\\right) }
+
+    where :math:`c_{XY} = \sum_{i} \delta_{u_{i} X} \delta_{v_{i} Y}`
+
+    Args:
+        u:           1-D bool array
+        v:           1-D bool array
+
+    Returns:
+        float:       Sokal-Sneath dissimilarity
+    """
+
+    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+
+    result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
+
+    result = (
+        (result_numer) /
+        (uv_mtx[1, 1] + result_numer)
+    )
+
+    return result

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -22,6 +22,7 @@ import dask_distance
         "rogerstanimoto",
         "russellrao",
         "sokalmichener",
+        "sokalsneath",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a function for computing the Sokal-Sneath dissimilarity of two 1-D bool arrays with Dask. Also tests it by comparing to the SciPy implementation of the same name.