### PR TITLE
Add yule

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -255,3 +255,34 @@ def sokalsneath(u, v):
     )
 
     return result
+
+
+def yule(u, v):
+    """
+    Finds the Yule dissimilarity between two 1-D bool arrays.
+
+    .. math::
+
+       \\frac{ 2 \cdot c_{TF} \cdot c_{FT} }
+             { c_{TT} \cdot c_{FF} + c_{TF} \cdot c_{FT} }
+
+    where :math:`c_{XY} = \sum_{i} \delta_{u_{i} X} \delta_{v_{i} Y}`
+
+    Args:
+        u:           1-D bool array
+        v:           1-D bool array
+
+    Returns:
+        float:       Yule dissimilarity
+    """
+
+    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+
+    uv_prod_mismtch = uv_mtx[1, 0] * uv_mtx[0, 1]
+
+    result = (
+        (2 * uv_prod_mismtch) /
+        (uv_mtx[1, 1] * uv_mtx[0, 0] + uv_prod_mismtch)
+    )
+
+    return result

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -23,6 +23,7 @@ import dask_distance
         "russellrao",
         "sokalmichener",
         "sokalsneath",
+        "yule",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a function for computing the Yule dissimilarity of two 1-D bool arrays with Dask. Also tests it by comparing to the SciPy implementation of the same name.