### PR TITLE
Drop period from dice docstring

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -30,7 +30,7 @@ def dice(u, v):
         v:           1-D bool array
 
     Returns:
-        float:       Dice dissimilarity.
+        float:       Dice dissimilarity
     """
 
     uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)


### PR DESCRIPTION
There was a period trailing the result description in the `dice` docstring. This felt a little weird since the description was not even a full sentence and other docstrings don't do this. Hence we drop the period from the end of the result description.