### PR TITLE
Fix _bool_cmp_mtx_cnt test name

### DIFF
--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -11,7 +11,7 @@ import numpy as np
 import dask_distance._utils
 
 
-def test_import_toplevel():
+def test__bool_cmp_mtx_cnt():
     u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=bool)
     v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=bool)
 


### PR DESCRIPTION
Still had the old import stub test's name. So this fixes it to be more descriptive of its current content.