### PR TITLE
Test mismatched bool array lengths raise

### DIFF
--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -11,6 +11,14 @@ import numpy as np
 import dask_distance._utils
 
 
+@pytest.mark.parametrize("et, u, v", [
+    (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
+])
+def test__bool_cmp_mtx_cnt_err(et, u, v):
+    with pytest.raises(et):
+        dask_distance._utils._bool_cmp_mtx_cnt(u, v)
+
+
 def test__bool_cmp_mtx_cnt():
     u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=bool)
     v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=bool)

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -26,6 +26,29 @@ import dask_distance
         "yule",
     ]
 )
+@pytest.mark.parametrize("et, u, v", [
+    (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
+])
+def test_1d_bool_dist_err(funcname, et, u, v):
+    da_func = getattr(dask_distance, funcname)
+
+    with pytest.raises(et):
+        da_func(u, v)
+
+
+@pytest.mark.parametrize(
+    "funcname", [
+        "dice",
+        "hamming",
+        "jaccard",
+        "kulsinski",
+        "rogerstanimoto",
+        "russellrao",
+        "sokalmichener",
+        "sokalsneath",
+        "yule",
+    ]
+)
 @pytest.mark.parametrize(
     "seed", [
         0,


### PR DESCRIPTION
Adds some tests for internal utility functions and user facing API functions to ensure that if any measurement is taken between two bool arrays that have different lengths, this will be raised as a `ValueError`.