### PR TITLE
Enforce 1D bool arrays

### DIFF
--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -8,6 +8,11 @@ def _bool_cmp_mtx_cnt(u, v):
     u = _compat._asarray(u)
     v = _compat._asarray(v)
 
+    if u.ndim != 1:
+        raise ValueError("u must be a 1-D array.")
+    if v.ndim != 1:
+        raise ValueError("v must be a 1-D array.")
+
     u_1 = u.astype(bool)
     v_1 = v.astype(bool)
     u_0 = ~u_1

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -13,6 +13,8 @@ import dask_distance._utils
 
 @pytest.mark.parametrize("et, u, v", [
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
+    (ValueError, np.zeros((1, 2,), dtype=bool), np.zeros((2,), dtype=bool)),
+    (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 2,), dtype=bool)),
 ])
 def test__bool_cmp_mtx_cnt_err(et, u, v):
     with pytest.raises(et):

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -28,6 +28,8 @@ import dask_distance
 )
 @pytest.mark.parametrize("et, u, v", [
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
+    (ValueError, np.zeros((1, 2,), dtype=bool), np.zeros((3,), dtype=bool)),
+    (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 3,), dtype=bool)),
 ])
 def test_1d_bool_dist_err(funcname, et, u, v):
     da_func = getattr(dask_distance, funcname)


### PR DESCRIPTION
Adds some tests for internal utility functions and user facing API functions to ensure that if any bool array is not 1D, this will be raised as a `ValueError`.