### PR TITLE
Sum over first two axes in hamming only

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -66,7 +66,7 @@ def hamming(u, v):
     uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
 
     result = (
-        (uv_mtx[1, 0] + uv_mtx[0, 1]) / (uv_mtx.sum())
+        (uv_mtx[1, 0] + uv_mtx[0, 1]) / (uv_mtx.sum(axis=(0, 1)))
     )
 
     return result


### PR DESCRIPTION
As we exploring comparing more than one array pair at a time, we need to be able to pass multiple axes through and only reduce some of them. Hence we adjust the `sum` in `hamming` to only reduce along the first two axes, which have been used to represent the True/False pair combinations. By making this change, it should be a trivial matter to extend `hamming` to performing multiple comparisons at a time.