### PR TITLE
Refresh wrong dimensions error message

### DIFF
--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -16,11 +16,6 @@ def _bool_cmp_cnts(U, V):
     U = U.astype(bool)
     V = V.astype(bool)
 
-    if U.ndim != 2:
-        raise ValueError("U must be a 2-D array.")
-    if V.ndim != 2:
-        raise ValueError("V must be a 2-D array.")
-
     U_bc = dask.array.repeat(U[:, None], len(V), axis=1)
     V_bc = dask.array.repeat(V[None, :], len(U), axis=0)
 
@@ -53,6 +48,11 @@ def _bool_cmp_mtx_cnt(u, v):
     V = v
     if V.ndim == 1:
         V = V[None]
+
+    if U.ndim != 2:
+        raise ValueError("u must be a 1-D or 2-D array.")
+    if V.ndim != 2:
+        raise ValueError("v must be a 1-D or 2-D array.")
 
     uv_cmp_mtx_cnts = _bool_cmp_cnts(U, V)
 


### PR DESCRIPTION
Previously the error raised when having a bool array of the wrong dimensionality suggested the bool array should be 2D. However 1D is also acceptable, but was not specified in the message. This fixes that issue by noting the bool array must be 1D or 2D.