### PR TITLE
Consolidate bool array utility functions

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -33,7 +33,7 @@ def dice(u, v):
         float:       Dice dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     uv_mismtch = uv_mtx[1, 0] + uv_mtx[0, 1]
 
@@ -63,7 +63,7 @@ def hamming(u, v):
         float:       Hamming distance
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     result = (
         (uv_mtx[1, 0] + uv_mtx[0, 1]) / (uv_mtx.sum(axis=(0, 1)))
@@ -90,7 +90,7 @@ def jaccard(u, v):
         float:       Jaccard-Needham dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     uv_mismtch = uv_mtx[1, 0] + uv_mtx[0, 1]
 
@@ -121,7 +121,7 @@ def kulsinski(u, v):
         float:       Kulsinski dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1]) + uv_mtx[0, 0]
 
@@ -152,7 +152,7 @@ def rogerstanimoto(u, v):
         float:       Rogers-Tanimoto dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
 
@@ -183,7 +183,7 @@ def russellrao(u, v):
         float:       Russell-Rao dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     result_numer = uv_mtx[1, 0] + uv_mtx[0, 1] + uv_mtx[0, 0]
 
@@ -214,7 +214,7 @@ def sokalmichener(u, v):
         float:       Sokal-Michener dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
 
@@ -245,7 +245,7 @@ def sokalsneath(u, v):
         float:       Sokal-Sneath dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
 
@@ -276,7 +276,7 @@ def yule(u, v):
         float:       Yule dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_mtx_cnt(u, v)
+    uv_mtx = _utils._bool_cmp_cnts(u, v)
 
     uv_prod_mismtch = uv_mtx[1, 0] * uv_mtx[0, 1]
 

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -9,9 +9,21 @@ from . import _compat
 from . import _pycompat
 
 
-def _bool_cmp_cnts(U, V):
-    U = _compat._asarray(U)
-    V = _compat._asarray(V)
+def _bool_cmp_cnts(u, v):
+    u = _compat._asarray(u)
+    v = _compat._asarray(v)
+
+    U = u
+    if U.ndim == 1:
+        U = U[None]
+    V = v
+    if V.ndim == 1:
+        V = V[None]
+
+    if U.ndim != 2:
+        raise ValueError("u must be a 1-D or 2-D array.")
+    if V.ndim != 2:
+        raise ValueError("v must be a 1-D or 2-D array.")
 
     U = U.astype(bool)
     V = V.astype(bool)
@@ -35,30 +47,10 @@ def _bool_cmp_cnts(U, V):
         UV_cmp_cnts = UV_cmp_cnts2
     UV_cmp_cnts = UV_cmp_cnts[()]
 
-    return UV_cmp_cnts
-
-
-def _bool_cmp_mtx_cnt(u, v):
-    u = _compat._asarray(u)
-    v = _compat._asarray(v)
-
-    U = u
-    if U.ndim == 1:
-        U = U[None]
-    V = v
-    if V.ndim == 1:
-        V = V[None]
-
-    if U.ndim != 2:
-        raise ValueError("u must be a 1-D or 2-D array.")
-    if V.ndim != 2:
-        raise ValueError("v must be a 1-D or 2-D array.")
-
-    uv_cmp_mtx_cnts = _bool_cmp_cnts(U, V)
-
+    uv_cmp_cnts = UV_cmp_cnts
     if v.ndim == 1:
-        uv_cmp_mtx_cnts = uv_cmp_mtx_cnts[:, :, :, 0]
+        uv_cmp_cnts = uv_cmp_cnts[:, :, :, 0]
     if u.ndim == 1:
-        uv_cmp_mtx_cnts = uv_cmp_mtx_cnts[:, :, 0]
+        uv_cmp_cnts = uv_cmp_cnts[:, :, 0]
 
-    return uv_cmp_mtx_cnts
+    return uv_cmp_cnts

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -25,14 +25,14 @@ def _bool_cmp_cnts(u, v):
     if V.ndim != 2:
         raise ValueError("v must be a 1-D or 2-D array.")
 
+    U = dask.array.repeat(U[:, None], len(V), axis=1)
+    V = dask.array.repeat(V[None, :], len(U), axis=0)
+
     U = U.astype(bool)
     V = V.astype(bool)
 
-    U_bc = dask.array.repeat(U[:, None], len(V), axis=1)
-    V_bc = dask.array.repeat(V[None, :], len(U), axis=0)
-
-    U_01 = [~U_bc, U_bc]
-    V_01 = [~V_bc, V_bc]
+    U_01 = [~U, U]
+    V_01 = [~V, V]
 
     UV_cmp_cnts = numpy.empty((2, 2), dtype=object)
     UV_ranges = [_pycompat.irange(e) for e in UV_cmp_cnts.shape]

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -16,27 +16,27 @@ import dask_distance._utils
     (ValueError, np.zeros((1, 2, 1,), dtype=bool), np.zeros((2,), dtype=bool)),
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 2, 1,), dtype=bool)),
 ])
-def test__bool_cmp_mtx_cnt_err(et, u, v):
+def test__bool_cmp_cnts_err(et, u, v):
     with pytest.raises(et):
-        dask_distance._utils._bool_cmp_mtx_cnt(u, v)
+        dask_distance._utils._bool_cmp_cnts(u, v)
 
 
-def test__bool_cmp_mtx_cnt_1d():
+def test__bool_cmp_cnts_1d():
     u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=bool)
     v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=bool)
 
-    uv_cmp_mtx = dask_distance._utils._bool_cmp_mtx_cnt(u, v)
+    uv_cmp_mtx = dask_distance._utils._bool_cmp_cnts(u, v)
 
     uv_cmp_mtx_exp = np.array([[1, 2], [3, 4]], dtype=float)
 
     assert (np.array(uv_cmp_mtx) == uv_cmp_mtx_exp).all()
 
 
-def test__bool_cmp_mtx_cnt_nd():
+def test__bool_cmp_cnts_nd():
     u = np.array([[0, 0, 0, 1, 1, 1, 1, 1, 1, 1]], dtype=bool)
     v = np.array([[0, 1, 1, 0, 0, 0, 1, 1, 1, 1]], dtype=bool)
 
-    uv_cmp_mtx = dask_distance._utils._bool_cmp_mtx_cnt(u, v)
+    uv_cmp_mtx = dask_distance._utils._bool_cmp_cnts(u, v)
 
     uv_cmp_mtx_exp = np.array([[[[1]], [[2]]], [[[3]], [[4]]]], dtype=float)
 


### PR DESCRIPTION
At this point most of the smarts are already in `_bool_cmp_cnts`. All that `_bool_cmp_mtx_cnt` still does is handle coercion of 1D bool arrays into 2D bool arrays. This same functionality can easily be gathered into `_bool_cmp_cnts`. Hence this moves all of the remaining logic into `_bool_cmp_cnts`. Interestingly this should make it easier to refactor some of this out into new more general utility functions.