### PR TITLE
Refactor _broadcast_uv

### DIFF
--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -32,23 +32,7 @@ def _broadcast_uv(u, v):
 
 
 def _bool_cmp_cnts(u, v):
-    u = _compat._asarray(u)
-    v = _compat._asarray(v)
-
-    U = u
-    if U.ndim == 1:
-        U = U[None]
-    V = v
-    if V.ndim == 1:
-        V = V[None]
-
-    if U.ndim != 2:
-        raise ValueError("u must be a 1-D or 2-D array.")
-    if V.ndim != 2:
-        raise ValueError("v must be a 1-D or 2-D array.")
-
-    U = dask.array.repeat(U[:, None], len(V), axis=1)
-    V = dask.array.repeat(V[None, :], len(U), axis=0)
+    U, V = _broadcast_uv(u, v)
 
     U = U.astype(bool)
     V = V.astype(bool)

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -9,6 +9,28 @@ from . import _compat
 from . import _pycompat
 
 
+def _broadcast_uv(u, v):
+    u = _compat._asarray(u)
+    v = _compat._asarray(v)
+
+    U = u
+    if U.ndim == 1:
+        U = U[None]
+    V = v
+    if V.ndim == 1:
+        V = V[None]
+
+    if U.ndim != 2:
+        raise ValueError("u must be a 1-D or 2-D array.")
+    if V.ndim != 2:
+        raise ValueError("v must be a 1-D or 2-D array.")
+
+    U = dask.array.repeat(U[:, None], len(V), axis=1)
+    V = dask.array.repeat(V[None, :], len(U), axis=0)
+
+    return U, V
+
+
 def _bool_cmp_cnts(u, v):
     u = _compat._asarray(u)
     v = _compat._asarray(v)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -8,6 +8,8 @@ import pytest
 
 import numpy as np
 
+import dask.array as da
+
 import dask_distance._utils
 
 
@@ -18,6 +20,21 @@ import dask_distance._utils
 def test__broadcast_uv_err(et, u, v):
     with pytest.raises(et):
         dask_distance._utils._broadcast_uv(u, v)
+
+
+def test__broadcast_uv():
+    u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1])
+    v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1])
+
+    U, V = dask_distance._utils._broadcast_uv(u, v)
+
+    for each in [U, V]:
+        assert isinstance(each, da.core.Array)
+
+    for new, old in [[U, u], [V, v]]:
+        assert new.dtype == old.dtype
+
+    assert U.shape == V.shape
 
 
 @pytest.mark.parametrize("et, u, v", [

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -12,6 +12,15 @@ import dask_distance._utils
 
 
 @pytest.mark.parametrize("et, u, v", [
+    (ValueError, np.zeros((1, 2, 1,), dtype=bool), np.zeros((2,), dtype=bool)),
+    (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 2, 1,), dtype=bool)),
+])
+def test__broadcast_uv_err(et, u, v):
+    with pytest.raises(et):
+        dask_distance._utils._broadcast_uv(u, v)
+
+
+@pytest.mark.parametrize("et, u, v", [
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
     (ValueError, np.zeros((1, 2, 1,), dtype=bool), np.zeros((2,), dtype=bool)),
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 2, 1,), dtype=bool)),


### PR DESCRIPTION
Creates a function to handle broadcasting of `u` and `v` so as to facilitate simpler computation with the two arrays. Use this function in `_bool_cmp_cnts`. Also add some basic tests for `_broadcast_uv`.