### PR TITLE
Add broadcast UV wrapper

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -15,6 +15,7 @@ del get_versions
 from . import _utils
 
 
+@_utils._broadcast_uv_wrapper
 def dice(u, v):
     """
     Finds the Dice dissimilarity between two 1-D bool arrays.
@@ -45,6 +46,7 @@ def dice(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def hamming(u, v):
     """
     Finds the Hamming distance between two 1-D bool arrays.
@@ -72,6 +74,7 @@ def hamming(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def jaccard(u, v):
     """
     Finds the Jaccard-Needham dissimilarity between two 1-D bool arrays.
@@ -102,6 +105,7 @@ def jaccard(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def kulsinski(u, v):
     """
     Finds the Kulsinski dissimilarity between two 1-D bool arrays.
@@ -133,6 +137,7 @@ def kulsinski(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def rogerstanimoto(u, v):
     """
     Finds the Rogers-Tanimoto dissimilarity between two 1-D bool arrays.
@@ -164,6 +169,7 @@ def rogerstanimoto(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def russellrao(u, v):
     """
     Finds the Russell-Rao dissimilarity between two 1-D bool arrays.
@@ -195,6 +201,7 @@ def russellrao(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def sokalmichener(u, v):
     """
     Finds the Sokal-Michener dissimilarity between two 1-D bool arrays.
@@ -226,6 +233,7 @@ def sokalmichener(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def sokalsneath(u, v):
     """
     Finds the Sokal-Sneath dissimilarity between two 1-D bool arrays.
@@ -257,6 +265,7 @@ def sokalsneath(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
 def yule(u, v):
     """
     Finds the Yule dissimilarity between two 1-D bool arrays.

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -49,8 +49,9 @@ def _broadcast_uv_wrapper(func):
     return _wrapped_broadcast_uv
 
 
-def _bool_cmp_cnts(u, v):
-    U, V = _broadcast_uv(u, v)
+def _bool_cmp_cnts(U, V):
+    U = _compat._asarray(U)
+    V = _compat._asarray(V)
 
     U = U.astype(bool)
     V = V.astype(bool)
@@ -71,10 +72,4 @@ def _bool_cmp_cnts(u, v):
         UV_cmp_cnts = UV_cmp_cnts2
     UV_cmp_cnts = UV_cmp_cnts[()]
 
-    uv_cmp_cnts = UV_cmp_cnts
-    if v.ndim == 1:
-        uv_cmp_cnts = uv_cmp_cnts[:, :, :, 0]
-    if u.ndim == 1:
-        uv_cmp_cnts = uv_cmp_cnts[:, :, 0]
-
-    return uv_cmp_cnts
+    return UV_cmp_cnts

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 
 import numpy
@@ -29,6 +30,23 @@ def _broadcast_uv(u, v):
     V = dask.array.repeat(V[None, :], len(U), axis=0)
 
     return U, V
+
+
+def _broadcast_uv_wrapper(func):
+    @functools.wraps(func)
+    def _wrapped_broadcast_uv(u, v):
+        U, V = _broadcast_uv(u, v)
+
+        result = func(U, V)
+
+        if v.ndim == 1:
+            result = result[:, 0]
+        if u.ndim == 1:
+            result = result[0]
+
+        return result
+
+    return _wrapped_broadcast_uv
 
 
 def _bool_cmp_cnts(u, v):

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -32,6 +32,18 @@ def _broadcast_uv(u, v):
     return U, V
 
 
+def _unbroadcast_uv(u, v, result):
+    u = _compat._asarray(u)
+    v = _compat._asarray(v)
+
+    if v.ndim == 1:
+        result = result[:, 0]
+    if u.ndim == 1:
+        result = result[0]
+
+    return result
+
+
 def _broadcast_uv_wrapper(func):
     @functools.wraps(func)
     def _wrapped_broadcast_uv(u, v):
@@ -39,10 +51,7 @@ def _broadcast_uv_wrapper(func):
 
         result = func(U, V)
 
-        if v.ndim == 1:
-            result = result[:, 0]
-        if u.ndim == 1:
-            result = result[0]
+        result = _unbroadcast_uv(u, v, result)
 
         return result
 

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -39,23 +39,10 @@ def test__broadcast_uv():
 
 @pytest.mark.parametrize("et, u, v", [
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
-    (ValueError, np.zeros((1, 2, 1,), dtype=bool), np.zeros((2,), dtype=bool)),
-    (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 2, 1,), dtype=bool)),
 ])
 def test__bool_cmp_cnts_err(et, u, v):
     with pytest.raises(et):
         dask_distance._utils._bool_cmp_cnts(u, v)
-
-
-def test__bool_cmp_cnts_1d():
-    u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=bool)
-    v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=bool)
-
-    uv_cmp_mtx = dask_distance._utils._bool_cmp_cnts(u, v)
-
-    uv_cmp_mtx_exp = np.array([[1, 2], [3, 4]], dtype=float)
-
-    assert (np.array(uv_cmp_mtx) == uv_cmp_mtx_exp).all()
 
 
 def test__bool_cmp_cnts_nd():

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -49,7 +49,10 @@ def test__bool_cmp_cnts_nd():
     u = np.array([[0, 0, 0, 1, 1, 1, 1, 1, 1, 1]], dtype=bool)
     v = np.array([[0, 1, 1, 0, 0, 0, 1, 1, 1, 1]], dtype=bool)
 
-    uv_cmp_mtx = dask_distance._utils._bool_cmp_cnts(u, v)
+    uv_cmp_mtx = dask_distance._utils._bool_cmp_cnts(
+        np.repeat(u[:, None], len(v), axis=1),
+        np.repeat(v[None], len(u), axis=0)
+    )
 
     uv_cmp_mtx_exp = np.array([[[[1]], [[2]]], [[[3]], [[4]]]], dtype=float)
 

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -37,6 +37,21 @@ def test__broadcast_uv():
     assert U.shape == V.shape
 
 
+def test__unbroadcast_uv():
+    u = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 1])
+    v = np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1])
+
+    U, V = dask_distance._utils._broadcast_uv(u, v)
+
+    result = U + V
+
+    result = dask_distance._utils._unbroadcast_uv(u, v, result)
+
+    assert isinstance(result, da.core.Array)
+
+    assert result.shape == u.shape
+
+
 @pytest.mark.parametrize("et, u, v", [
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((3,), dtype=bool)),
 ])


### PR DESCRIPTION
Adds a wrapper to handle broadcasting and unbroadcasting of `u` and `v` for computation by the various distance and dissimilarity functions. Should cutdown on overhead and improve test coverage of the internal utility functions. Also should simplify the amount of boilerplate used in both bool array functions and distance functions.