### PR TITLE
Independently vary bool arrays' shapes and chunks in 2D tests

### DIFF
--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -102,18 +102,18 @@ def test_1d_bool_dist(funcname, seed, size, chunks):
     ]
 )
 @pytest.mark.parametrize(
-    "size, chunks", [
-        ((3, 10), (1, 5)),
+    "u_shape, u_chunks, v_shape, v_chunks", [
+        ((3, 10), (1, 5), (3, 10), (1, 5)),
     ]
 )
-def test_2d_bool_dist(funcname, seed, size, chunks):
+def test_2d_bool_dist(funcname, seed, u_shape, u_chunks, v_shape, v_chunks):
     np.random.seed(seed)
 
-    a_u = np.random.randint(0, 2, size, dtype=bool)
-    a_v = np.random.randint(0, 2, size, dtype=bool)
+    a_u = np.random.randint(0, 2, u_shape, dtype=bool)
+    a_v = np.random.randint(0, 2, v_shape, dtype=bool)
 
-    d_u = da.from_array(a_u, chunks=chunks)
-    d_v = da.from_array(a_v, chunks=chunks)
+    d_u = da.from_array(a_u, chunks=u_chunks)
+    d_v = da.from_array(a_v, chunks=v_chunks)
 
     da_func = getattr(dask_distance, funcname)
 

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -103,7 +103,7 @@ def test_1d_bool_dist(funcname, seed, size, chunks):
 )
 @pytest.mark.parametrize(
     "u_shape, u_chunks, v_shape, v_chunks", [
-        ((3, 10), (1, 5), (3, 10), (1, 5)),
+        ((2, 10), (1, 5), (3, 10), (1, 5)),
     ]
 )
 def test_2d_bool_dist(funcname, seed, u_shape, u_chunks, v_shape, v_chunks):


### PR DESCRIPTION
Allow the shapes and chunk sizes of the two bool arrays in the 2D tests to vary independently. This should help catch weird dimensionality issues that can crop up.