### PR TITLE
Drop references to uv comparison being a matrix

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -41,13 +41,13 @@ def dice(u, v):
         float:       Dice dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    uv_mismtch = uv_mtx[1, 0] + uv_mtx[0, 1]
+    uv_mismtch = uv_cmp[1, 0] + uv_cmp[0, 1]
 
     result = (
         (uv_mismtch) /
-        (2 * uv_mtx[1, 1] + uv_mismtch)
+        (2 * uv_cmp[1, 1] + uv_mismtch)
     )
 
     return result
@@ -72,10 +72,10 @@ def hamming(u, v):
         float:       Hamming distance
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
     result = (
-        (uv_mtx[1, 0] + uv_mtx[0, 1]) / (uv_mtx.sum(axis=(0, 1)))
+        (uv_cmp[1, 0] + uv_cmp[0, 1]) / (uv_cmp.sum(axis=(0, 1)))
     )
 
     return result
@@ -100,13 +100,13 @@ def jaccard(u, v):
         float:       Jaccard-Needham dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    uv_mismtch = uv_mtx[1, 0] + uv_mtx[0, 1]
+    uv_mismtch = uv_cmp[1, 0] + uv_cmp[0, 1]
 
     result = (
         (uv_mismtch) /
-        (uv_mtx[1, 1] + uv_mismtch)
+        (uv_cmp[1, 1] + uv_mismtch)
     )
 
     return result
@@ -132,13 +132,13 @@ def kulsinski(u, v):
         float:       Kulsinski dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1]) + uv_mtx[0, 0]
+    result_numer = 2 * (uv_cmp[1, 0] + uv_cmp[0, 1]) + uv_cmp[0, 0]
 
     result = (
         (result_numer) /
-        (uv_mtx[1, 1] + result_numer)
+        (uv_cmp[1, 1] + result_numer)
     )
 
     return result
@@ -164,13 +164,13 @@ def rogerstanimoto(u, v):
         float:       Rogers-Tanimoto dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
+    result_numer = 2 * (uv_cmp[1, 0] + uv_cmp[0, 1])
 
     result = (
         (result_numer) /
-        (uv_mtx[1, 1] + result_numer + uv_mtx[0, 0])
+        (uv_cmp[1, 1] + result_numer + uv_cmp[0, 0])
     )
 
     return result
@@ -196,13 +196,13 @@ def russellrao(u, v):
         float:       Russell-Rao dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    result_numer = uv_mtx[1, 0] + uv_mtx[0, 1] + uv_mtx[0, 0]
+    result_numer = uv_cmp[1, 0] + uv_cmp[0, 1] + uv_cmp[0, 0]
 
     result = (
         (result_numer) /
-        (uv_mtx[1, 1] + result_numer)
+        (uv_cmp[1, 1] + result_numer)
     )
 
     return result
@@ -228,13 +228,13 @@ def sokalmichener(u, v):
         float:       Sokal-Michener dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
+    result_numer = 2 * (uv_cmp[1, 0] + uv_cmp[0, 1])
 
     result = (
         (result_numer) /
-        (uv_mtx[1, 1] + result_numer + uv_mtx[0, 0])
+        (uv_cmp[1, 1] + result_numer + uv_cmp[0, 0])
     )
 
     return result
@@ -260,13 +260,13 @@ def sokalsneath(u, v):
         float:       Sokal-Sneath dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    result_numer = 2 * (uv_mtx[1, 0] + uv_mtx[0, 1])
+    result_numer = 2 * (uv_cmp[1, 0] + uv_cmp[0, 1])
 
     result = (
         (result_numer) /
-        (uv_mtx[1, 1] + result_numer)
+        (uv_cmp[1, 1] + result_numer)
     )
 
     return result
@@ -292,13 +292,13 @@ def yule(u, v):
         float:       Yule dissimilarity
     """
 
-    uv_mtx = _utils._bool_cmp_cnts(u, v)
+    uv_cmp = _utils._bool_cmp_cnts(u, v)
 
-    uv_prod_mismtch = uv_mtx[1, 0] * uv_mtx[0, 1]
+    uv_prod_mismtch = uv_cmp[1, 0] * uv_cmp[0, 1]
 
     result = (
         (2 * uv_prod_mismtch) /
-        (uv_mtx[1, 1] * uv_mtx[0, 0] + uv_prod_mismtch)
+        (uv_cmp[1, 1] * uv_cmp[0, 0] + uv_prod_mismtch)
     )
 
     return result

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -64,11 +64,11 @@ def test__bool_cmp_cnts_nd():
     u = np.array([[0, 0, 0, 1, 1, 1, 1, 1, 1, 1]], dtype=bool)
     v = np.array([[0, 1, 1, 0, 0, 0, 1, 1, 1, 1]], dtype=bool)
 
-    uv_cmp_mtx = dask_distance._utils._bool_cmp_cnts(
+    uv_cmp = dask_distance._utils._bool_cmp_cnts(
         np.repeat(u[:, None], len(v), axis=1),
         np.repeat(v[None], len(u), axis=0)
     )
 
-    uv_cmp_mtx_exp = np.array([[[[1]], [[2]]], [[[3]], [[4]]]], dtype=float)
+    uv_cmp_exp = np.array([[[[1]], [[2]]], [[[3]], [[4]]]], dtype=float)
 
-    assert (np.array(uv_cmp_mtx) == uv_cmp_mtx_exp).all()
+    assert (np.array(uv_cmp) == uv_cmp_exp).all()


### PR DESCRIPTION
These names made more sense when the `uv` comparison was actually a matrix. However now it is a multidimensional array even in the 1D case. So it makes more sense to rename them to just note this is a comparison of `u` and `v` instead.