### PR TITLE
Add canberra

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -48,6 +48,32 @@ def braycurtis(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
+def canberra(u, v):
+    """
+    Finds the Canberra distance between two 1-D arrays.
+
+    .. math::
+
+       \sum_{i} \\frac{ \lvert u_{i} - v_{i} \\rvert }
+                      { \lvert u_{i} \\rvert + \lvert v_{i} \\rvert }
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+
+    Returns:
+        float:       Canberra distance
+    """
+
+    u = u.astype(float)
+    v = v.astype(float)
+
+    result = (abs(u - v) / (abs(u) + abs(v))).sum(axis=-1)
+
+    return result
+
+
 #####################################################
 #                                                   #
 #  Boolean vector distance/dissimilarity functions  #

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -16,6 +16,7 @@ import dask_distance
 @pytest.mark.parametrize(
     "funcname", [
         "braycurtis",
+        "canberra",
     ]
 )
 @pytest.mark.parametrize("et, u, v", [
@@ -33,6 +34,7 @@ def test_1d_dist_err(funcname, et, u, v):
 @pytest.mark.parametrize(
     "funcname", [
         "braycurtis",
+        "canberra",
     ]
 )
 @pytest.mark.parametrize(
@@ -68,6 +70,7 @@ def test_1d_dist(funcname, seed, size, chunks):
 @pytest.mark.parametrize(
     "funcname", [
         "braycurtis",
+        "canberra",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a Dask array function for computing the Canberra distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.