### PR TITLE
Add chebyshev

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -74,6 +74,31 @@ def canberra(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
+def chebyshev(u, v):
+    """
+    Finds the Chebyshev distance between two 1-D arrays.
+
+    .. math::
+
+       \max_{i} \lvert u_{i} - v_{i} \\rvert
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+
+    Returns:
+        float:       Chebyshev distance
+    """
+
+    u = u.astype(float)
+    v = v.astype(float)
+
+    result = abs(u - v).max(axis=-1)
+
+    return result
+
+
 #####################################################
 #                                                   #
 #  Boolean vector distance/dissimilarity functions  #

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -17,6 +17,7 @@ import dask_distance
     "funcname", [
         "braycurtis",
         "canberra",
+        "chebyshev",
     ]
 )
 @pytest.mark.parametrize("et, u, v", [
@@ -35,6 +36,7 @@ def test_1d_dist_err(funcname, et, u, v):
     "funcname", [
         "braycurtis",
         "canberra",
+        "chebyshev",
     ]
 )
 @pytest.mark.parametrize(
@@ -71,6 +73,7 @@ def test_1d_dist(funcname, seed, size, chunks):
     "funcname", [
         "braycurtis",
         "canberra",
+        "chebyshev",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a Dask array function for computing the Chebyshev distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.