### PR TITLE
Add cityblock

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -99,6 +99,31 @@ def chebyshev(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
+def cityblock(u, v):
+    """
+    Finds the City Block (Manhattan) distance between two 1-D arrays.
+
+    .. math::
+
+       \sum_{i} \lvert u_{i} - v_{i} \\rvert
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+
+    Returns:
+        float:       City Block (Manhattan) distance
+    """
+
+    u = u.astype(float)
+    v = v.astype(float)
+
+    result = abs(u - v).sum(axis=-1)
+
+    return result
+
+
 #####################################################
 #                                                   #
 #  Boolean vector distance/dissimilarity functions  #

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -18,6 +18,7 @@ import dask_distance
         "braycurtis",
         "canberra",
         "chebyshev",
+        "cityblock",
     ]
 )
 @pytest.mark.parametrize("et, u, v", [
@@ -37,6 +38,7 @@ def test_1d_dist_err(funcname, et, u, v):
         "braycurtis",
         "canberra",
         "chebyshev",
+        "cityblock",
     ]
 )
 @pytest.mark.parametrize(
@@ -74,6 +76,7 @@ def test_1d_dist(funcname, seed, size, chunks):
         "braycurtis",
         "canberra",
         "chebyshev",
+        "cityblock",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a Dask array function for computing the City Block (Manhattan) distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.