### PR TITLE
Add correlation

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -124,6 +124,44 @@ def cityblock(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
+def correlation(u, v):
+    """
+    Finds the correlation distance between two 1-D arrays.
+
+    .. math::
+
+       1 - \\frac{ (u - \\bar{u}) \cdot (v - \\bar{v}) }
+                 {
+                    \lVert u - \\bar{u} \\rVert_{2}
+                    \lVert v - \\bar{v} \\rVert_{2}
+                 }
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+
+    Returns:
+        float:       correlation distance
+    """
+
+    u = u.astype(float)
+    v = v.astype(float)
+
+    u_mean = u.mean(axis=-1, keepdims=True)
+    v_mean = v.mean(axis=-1, keepdims=True)
+
+    result = 1 - (
+        ((u - u_mean) * (v - v_mean)).sum(axis=-1) /
+        (
+            (abs(u - u_mean) ** 2).sum(axis=-1) ** 0.5 *
+            (abs(v - v_mean) ** 2).sum(axis=-1) ** 0.5
+        )
+    )
+
+    return result
+
+
 #####################################################
 #                                                   #
 #  Boolean vector distance/dissimilarity functions  #

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -19,6 +19,7 @@ import dask_distance
         "canberra",
         "chebyshev",
         "cityblock",
+        "correlation",
     ]
 )
 @pytest.mark.parametrize("et, u, v", [
@@ -39,6 +40,7 @@ def test_1d_dist_err(funcname, et, u, v):
         "canberra",
         "chebyshev",
         "cityblock",
+        "correlation",
     ]
 )
 @pytest.mark.parametrize(
@@ -77,6 +79,7 @@ def test_1d_dist(funcname, seed, size, chunks):
         "canberra",
         "chebyshev",
         "cityblock",
+        "correlation",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a Dask array function for computing the correlation distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.