### PR TITLE
Add euclidean

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -194,6 +194,31 @@ def cosine(u, v):
     return result
 
 
+@_utils._broadcast_uv_wrapper
+def euclidean(u, v):
+    """
+    Finds the Euclidean distance between two 1-D arrays.
+
+    .. math::
+
+       \lVert u - v \\rVert_{2}
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+
+    Returns:
+        float:       Cosine distance
+    """
+
+    u = u.astype(float)
+    v = v.astype(float)
+
+    result = (abs(u - v) ** 2).sum(axis=-1) ** 0.5
+
+    return result
+
+
 #####################################################
 #                                                   #
 #  Boolean vector distance/dissimilarity functions  #

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -21,6 +21,7 @@ import dask_distance
         "cityblock",
         "correlation",
         "cosine",
+        "euclidean",
     ]
 )
 @pytest.mark.parametrize("et, u, v", [
@@ -43,6 +44,7 @@ def test_1d_dist_err(funcname, et, u, v):
         "cityblock",
         "correlation",
         "cosine",
+        "euclidean",
     ]
 )
 @pytest.mark.parametrize(
@@ -83,6 +85,7 @@ def test_1d_dist(funcname, seed, size, chunks):
         "cityblock",
         "correlation",
         "cosine",
+        "euclidean",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements a Dask array function for computing the Euclidean distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.