### PR TITLE
Run flake8 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ script:
   - coverage run --source . setup.py test
   - coverage report -m
 
+  # Do some basic linting of the code.
+  - flake8 .
+
 # Report coverage
 after_success:
   - source activate root

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
   # Install the package and dependencies.
   - pip install -e .
 
-# command to run tests, e.g. python setup.py test
 script:
+  # Run our test suite and report coverage.
   - coverage erase
   - coverage run --source . setup.py test
   - coverage report -m

--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -9,6 +9,7 @@ dependencies:
   - coverage==4.0.3
   - python-coveralls==2.7.0
   - pytest==3.0.5
+  - flake8==3.2.1
   - dask==0.13.0
   - numpy==1.11.3
   - scipy==0.19.1


### PR DESCRIPTION
Start running flake8 as part of all CI builds. Make sure flake8 is added and version fixed in our CI requirements as well. Should help make sure the code quality here remains ok (especially since we have fixed some issues 😉).