### PR TITLE
Fix the euclidean docstring

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -206,7 +206,7 @@ def euclidean(u, v):
         v:           1-D array or collection of 1-D arrays
 
     Returns:
-        float:       Cosine distance
+        float:       Euclidean distance
     """
 
     u = u.astype(float)


### PR DESCRIPTION
Had mentioned the returned result was the "Cosine distance", which was incorrect. Have updated it to correctly state the returned result is the "Euclidean distance".