### PR TITLE
Add izip

### DIFF
--- a/dask_distance/_pycompat.py
+++ b/dask_distance/_pycompat.py
@@ -5,3 +5,8 @@ try:
     irange = xrange
 except NameError:
     irange = range
+
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip

--- a/tests/test__pycompat.py
+++ b/tests/test__pycompat.py
@@ -13,3 +13,11 @@ def test_irange():
     assert not isinstance(r, list)
 
     assert list(r) == [0, 1, 2, 3, 4]
+
+
+def test_izip():
+    r = dask_distance._pycompat.izip([1, 2, 3], ["a", "b", "c"])
+
+    assert not isinstance(r, list)
+
+    assert list(r) == [(1, 'a'), (2, 'b'), (3, 'c')]


### PR DESCRIPTION
Adds an iterable form of `izip` for both Python 2 and Python 3 by reusing the available iterable `zip` on either Python version. Includes a basic test that verifies `izip` exists and functions ok.