### PR TITLE
Add pdist

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -93,6 +93,35 @@ def cdist(XA, XB, metric="euclidean"):
     return result
 
 
+def pdist(X, metric="euclidean"):
+    """
+    Finds the pairwise condensed distance matrix using the metric.
+
+    Args:
+        X:          2-D array of points
+        metric:     string or callable
+
+    Returns:
+        array:      condensed distance between each pair
+
+    Note:
+        Tries to avoid redundant computations as much as possible.
+        However this is limited in its ability to do this based on
+        the chunk size of X (particularly along the first dimension).
+        Smaller chunks will increase savings though there may be
+        other tradeoffs.
+    """
+
+    result = cdist(X, X, metric)
+
+    result = dask.array.triu(result, 1)
+
+    indices = _compat._indices(result.shape, chunks=result.chunks)
+    result = result[indices[1] > indices[0]]
+
+    return result
+
+
 #######################################
 #                                     #
 #  Numeric vector distance functions  #

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -120,6 +120,43 @@ def test_2d_cdist(metric, seed, u_shape, u_chunks, v_shape, v_chunks):
 
 
 @pytest.mark.parametrize(
+    "metric", [
+        "braycurtis",
+        "canberra",
+        "chebyshev",
+        "cityblock",
+        "correlation",
+        "cosine",
+        "euclidean",
+        "sqeuclidean",
+        lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0),
+    ]
+)
+@pytest.mark.parametrize(
+    "seed", [
+        0,
+        137,
+        34,
+    ]
+)
+@pytest.mark.parametrize(
+    "u_shape, u_chunks", [
+        ((3, 10), (1, 5)),
+    ]
+)
+def test_2d_pdist(metric, seed, u_shape, u_chunks):
+    np.random.seed(seed)
+
+    a_u = 2 * np.random.random(u_shape) - 1
+    d_u = da.from_array(a_u, chunks=u_chunks)
+
+    a_r = spdist.pdist(a_u, metric)
+    d_r = dask_distance.pdist(d_u, metric)
+
+    assert np.allclose(np.array(d_r)[()], a_r, equal_nan=True)
+
+
+@pytest.mark.parametrize(
     "funcname", [
         "dice",
         "hamming",
@@ -224,5 +261,43 @@ def test_2d_bool_cdist(metric, seed, u_shape, u_chunks, v_shape, v_chunks):
 
     a_r = spdist.cdist(a_u, a_v, metric)
     d_r = dask_distance.cdist(d_u, d_v, metric)
+
+    assert np.allclose(np.array(d_r)[()], a_r, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    "metric", [
+        "dice",
+        "hamming",
+        "jaccard",
+        "kulsinski",
+        "rogerstanimoto",
+        "russellrao",
+        "sokalmichener",
+        "sokalsneath",
+        "yule",
+        lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0),
+    ]
+)
+@pytest.mark.parametrize(
+    "seed", [
+        0,
+        137,
+        34,
+    ]
+)
+@pytest.mark.parametrize(
+    "u_shape, u_chunks", [
+        ((3, 10), (1, 5)),
+    ]
+)
+def test_2d_bool_pdist(metric, seed, u_shape, u_chunks):
+    np.random.seed(seed)
+
+    a_u = np.random.randint(0, 2, u_shape, dtype=bool)
+    d_u = da.from_array(a_u, chunks=u_chunks)
+
+    a_r = spdist.pdist(a_u, metric)
+    d_r = dask_distance.pdist(d_u, metric)
 
     assert np.allclose(np.array(d_r)[()], a_r, equal_nan=True)


### PR DESCRIPTION
Implements `pdist` for computing distances within a set of points. Supports metrics that we have already implemented and provides the option for users to give their own. Borrows the `cdist` tests with some tweaks for use with `pdist`. Still makes sure that this matches SciPy's `pdist` in terms of behavior.

<b>Note:</b> This implementation tries to avoid redundant computations as much as possible. However this is limited in its ability to do this based on the chunk size of `X` (particularly along the first dimension). Smaller chunks will increase savings though there may be other tradeoffs.