### PR TITLE
Test with optional keyword arguments

### DIFF
--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -14,15 +14,15 @@ import dask_distance
 
 
 @pytest.mark.parametrize(
-    "funcname", [
-        "braycurtis",
-        "canberra",
-        "chebyshev",
-        "cityblock",
-        "correlation",
-        "cosine",
-        "euclidean",
-        "sqeuclidean",
+    "funcname, kw", [
+        ("braycurtis", {}),
+        ("canberra", {}),
+        ("chebyshev", {}),
+        ("cityblock", {}),
+        ("correlation", {}),
+        ("cosine", {}),
+        ("euclidean", {}),
+        ("sqeuclidean", {}),
     ]
 )
 @pytest.mark.parametrize("et, u, v", [
@@ -30,23 +30,23 @@ import dask_distance
     (ValueError, np.zeros((1, 2, 1,), dtype=bool), np.zeros((3,), dtype=bool)),
     (ValueError, np.zeros((2,), dtype=bool), np.zeros((1, 3, 1,), dtype=bool)),
 ])
-def test_1d_dist_err(funcname, et, u, v):
+def test_1d_dist_err(funcname, kw, et, u, v):
     da_func = getattr(dask_distance, funcname)
 
     with pytest.raises(et):
-        da_func(u, v)
+        da_func(u, v, **kw)
 
 
 @pytest.mark.parametrize(
-    "funcname", [
-        "braycurtis",
-        "canberra",
-        "chebyshev",
-        "cityblock",
-        "correlation",
-        "cosine",
-        "euclidean",
-        "sqeuclidean",
+    "funcname, kw", [
+        ("braycurtis", {}),
+        ("canberra", {}),
+        ("chebyshev", {}),
+        ("cityblock", {}),
+        ("correlation", {}),
+        ("cosine", {}),
+        ("euclidean", {}),
+        ("sqeuclidean", {}),
     ]
 )
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ def test_1d_dist_err(funcname, et, u, v):
         (10, 5),
     ]
 )
-def test_1d_dist(funcname, seed, size, chunks):
+def test_1d_dist(funcname, kw, seed, size, chunks):
     np.random.seed(seed)
 
     a_u = 2 * np.random.random((size,)) - 1
@@ -73,23 +73,23 @@ def test_1d_dist(funcname, seed, size, chunks):
     sp_func = getattr(spdist, funcname)
     da_func = getattr(dask_distance, funcname)
 
-    a_r = sp_func(a_u, a_v)
-    d_r = da_func(d_u, d_v)
+    a_r = sp_func(a_u, a_v, **kw)
+    d_r = da_func(d_u, d_v, **kw)
 
     assert np.allclose(np.array(d_r)[()], a_r, equal_nan=True)
 
 
 @pytest.mark.parametrize(
-    "metric", [
-        "braycurtis",
-        "canberra",
-        "chebyshev",
-        "cityblock",
-        "correlation",
-        "cosine",
-        "euclidean",
-        "sqeuclidean",
-        lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0),
+    "metric, kw", [
+        ("braycurtis", {}),
+        ("canberra", {}),
+        ("chebyshev", {}),
+        ("cityblock", {}),
+        ("correlation", {}),
+        ("cosine", {}),
+        ("euclidean", {}),
+        ("sqeuclidean", {}),
+        (lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0), {}),
     ]
 )
 @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ def test_1d_dist(funcname, seed, size, chunks):
         ((2, 10), (1, 5), (3, 10), (1, 5)),
     ]
 )
-def test_2d_cdist(metric, seed, u_shape, u_chunks, v_shape, v_chunks):
+def test_2d_cdist(metric, kw, seed, u_shape, u_chunks, v_shape, v_chunks):
     np.random.seed(seed)
 
     a_u = 2 * np.random.random(u_shape) - 1
@@ -113,23 +113,23 @@ def test_2d_cdist(metric, seed, u_shape, u_chunks, v_shape, v_chunks):
     d_u = da.from_array(a_u, chunks=u_chunks)
     d_v = da.from_array(a_v, chunks=v_chunks)
 
-    a_r = spdist.cdist(a_u, a_v, metric)
-    d_r = dask_distance.cdist(d_u, d_v, metric)
+    a_r = spdist.cdist(a_u, a_v, metric, **kw)
+    d_r = dask_distance.cdist(d_u, d_v, metric, **kw)
 
     assert np.allclose(np.array(d_r)[()], a_r, equal_nan=True)
 
 
 @pytest.mark.parametrize(
-    "metric", [
-        "braycurtis",
-        "canberra",
-        "chebyshev",
-        "cityblock",
-        "correlation",
-        "cosine",
-        "euclidean",
-        "sqeuclidean",
-        lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0),
+    "metric, kw", [
+        ("braycurtis", {}),
+        ("canberra", {}),
+        ("chebyshev", {}),
+        ("cityblock", {}),
+        ("correlation", {}),
+        ("cosine", {}),
+        ("euclidean", {}),
+        ("sqeuclidean", {}),
+        (lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0), {}),
     ]
 )
 @pytest.mark.parametrize(
@@ -144,14 +144,14 @@ def test_2d_cdist(metric, seed, u_shape, u_chunks, v_shape, v_chunks):
         ((3, 10), (1, 5)),
     ]
 )
-def test_2d_pdist(metric, seed, u_shape, u_chunks):
+def test_2d_pdist(metric, kw, seed, u_shape, u_chunks):
     np.random.seed(seed)
 
     a_u = 2 * np.random.random(u_shape) - 1
     d_u = da.from_array(a_u, chunks=u_chunks)
 
-    a_r = spdist.pdist(a_u, metric)
-    d_r = dask_distance.pdist(d_u, metric)
+    a_r = spdist.pdist(a_u, metric, **kw)
+    d_r = dask_distance.pdist(d_u, metric, **kw)
 
     assert np.allclose(np.array(d_r)[()], a_r, equal_nan=True)
 


### PR DESCRIPTION
Adjust the tests so that one can supply optional keyword arguments to each test function. This should make it easier to test functions that require another argument beyond the two points (or sets of points).