### PR TITLE
Support the minkowski metric in cdist and pdist

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -24,7 +24,7 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 #######################################
 
 
-def cdist(XA, XB, metric="euclidean"):
+def cdist(XA, XB, metric="euclidean", p=None):
     """
     Finds the distance matrix using the metric on each pair of points.
 
@@ -32,6 +32,7 @@ def cdist(XA, XB, metric="euclidean"):
         XA:         2-D array of points
         XB:         2-D array of points
         metric:     string or callable
+        p:          p-norm for minkowski only (default: 2)
 
     Returns:
         array:      distance between each combination of points
@@ -49,6 +50,7 @@ def cdist(XA, XB, metric="euclidean"):
         "hamming": hamming,
         "jaccard": jaccard,
         "kulsinski": kulsinski,
+        "minkowski": minkowski,
         "rogerstanimoto": rogerstanimoto,
         "russellrao": russellrao,
         "sokalmichener": sokalmichener,
@@ -88,18 +90,24 @@ def cdist(XA, XB, metric="euclidean"):
 
         metric = func_mappings[metric]
 
-        result = metric(XA, XB)
+        if metric == minkowski:
+            if p is None:
+                p = 2
+            result = metric(XA, XB, p)
+        else:
+            result = metric(XA, XB)
 
     return result
 
 
-def pdist(X, metric="euclidean"):
+def pdist(X, metric="euclidean", p=None):
     """
     Finds the pairwise condensed distance matrix using the metric.
 
     Args:
         X:          2-D array of points
         metric:     string or callable
+        p:          p-norm for minkowski only (default: 2)
 
     Returns:
         array:      condensed distance between each pair
@@ -112,7 +120,7 @@ def pdist(X, metric="euclidean"):
         other tradeoffs.
     """
 
-    result = cdist(X, X, metric)
+    result = cdist(X, X, metric, p=p)
 
     result = dask.array.triu(result, 1)
 

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -92,6 +92,8 @@ def test_1d_dist(funcname, kw, seed, size, chunks):
         ("correlation", {}),
         ("cosine", {}),
         ("euclidean", {}),
+        ("minkowski", {}),
+        ("minkowski", {"p": 3}),
         ("sqeuclidean", {}),
         (lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0), {}),
     ]
@@ -132,6 +134,8 @@ def test_2d_cdist(metric, kw, seed, u_shape, u_chunks, v_shape, v_chunks):
         ("correlation", {}),
         ("cosine", {}),
         ("euclidean", {}),
+        ("minkowski", {}),
+        ("minkowski", {"p": 3}),
         ("sqeuclidean", {}),
         (lambda u, v: (abs(u - v) ** 3).sum() ** (1.0 / 3.0), {}),
     ]


### PR DESCRIPTION
Makes sure that the minkowski metric can be selected when using either `cdist` or `pdist`. Provide support for passing along `p` to the `minkowski` function. Also set `p` to `2` if it is undefined. Provide tests comparing the results from `cdist` and `pdist` when using the minkowski metric to those from SciPy to make sure they are consistent. Also tests the case when `p` is not defined for both `cdist` and `pdist`.