### PR TITLE
Add seuclidean

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -365,6 +365,44 @@ def minkowski(u, v, p):
     return result
 
 
+def seuclidean(u, v, V):
+    """
+    Finds the standardized Euclidean distance between two 1-D arrays.
+
+    .. math::
+
+       \sqrt{\sum_{i} \left( \\frac{u_{i}^{2} - v_{i}^{2}}{V_{i}} \\right)}
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+        V:           1-D array of variances
+
+    Returns:
+        float:       standardized Euclidean
+    """
+
+    var = V
+    del V
+
+    var = _compat._asarray(var)
+    if var.ndim != 1:
+        raise ValueError("V must have a dimension of 1.")
+
+    U, V = _utils._broadcast_uv(u, v)
+    Var = var[None, None].repeat(U.shape[0], axis=0).repeat(U.shape[1], axis=1)
+
+    U = U.astype(float)
+    V = V.astype(float)
+    Var = Var.astype(float)
+
+    result = dask.array.sqrt(((abs(U - V) ** 2) / Var).sum(axis=-1))
+
+    result = _utils._unbroadcast_uv(u, v, result)
+
+    return result
+
+
 @_utils._broadcast_uv_wrapper
 def sqeuclidean(u, v):
     """

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -24,6 +24,7 @@ import dask_distance
         ("euclidean", {}),
         ("minkowski", {"p": 3}),
         ("minkowski", {"p": 1.4}),
+        ("seuclidean", {"V": 1}),
         ("sqeuclidean", {}),
         ("wminkowski", {"p": 3, "w": 1}),
     ]
@@ -51,6 +52,7 @@ def test_1d_dist_err(funcname, kw, et, u, v):
         ("euclidean", {}),
         ("minkowski", {"p": 3}),
         ("minkowski", {"p": 1.4}),
+        ("seuclidean", {}),
         ("sqeuclidean", {}),
         ("wminkowski", {"p": 4}),
         ("wminkowski", {"p": 1.6}),
@@ -80,7 +82,9 @@ def test_1d_dist(funcname, kw, seed, size, chunks):
     sp_func = getattr(spdist, funcname)
     da_func = getattr(dask_distance, funcname)
 
-    if funcname == "wminkowski":
+    if funcname == "seuclidean":
+        kw["V"] = 2 * np.random.random((size,)) - 1
+    elif funcname == "wminkowski":
         kw["w"] = 2 * np.random.random((size,)) - 1
 
     a_r = sp_func(a_u, a_v, **kw)


### PR DESCRIPTION
Partially addresses issue ( https://github.com/jakirkham/dask-distance/issues/54 ).

Implements a Dask array function for computing the standardized Euclidean distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.