### PR TITLE
Add mahalanobis

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -334,6 +334,43 @@ def euclidean(u, v):
     return result
 
 
+def mahalanobis(u, v, VI):
+    """
+    Finds the Mahalanobis distance between two 1-D arrays.
+
+    .. math::
+
+       \sqrt{ (u - v) \cdot V^{-1} \cdot (u - v)^{T} }
+
+    Args:
+        u:           1-D array or collection of 1-D arrays
+        v:           1-D array or collection of 1-D arrays
+        V:           Inverse of the covariance matrix
+
+    Returns:
+        float:       Mahalanobis distance
+    """
+
+    VI = _compat._asarray(VI)
+    if VI.ndim != 2:
+        raise ValueError("VI must have a dimension of 2.")
+
+    U, V = _utils._broadcast_uv(u, v)
+
+    U = U.astype(float)
+    V = V.astype(float)
+    VI = VI.astype(float)
+
+    U_sub_V = U - V
+    result = dask.array.sqrt(
+        (dask.array.tensordot(U_sub_V, VI, axes=1) * U_sub_V).sum(axis=-1)
+    )
+
+    result = _utils._unbroadcast_uv(u, v, result)
+
+    return result
+
+
 def minkowski(u, v, p):
     """
     Finds the Minkowski distance between two 1-D arrays.

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -22,6 +22,7 @@ import dask_distance
         ("correlation", {}),
         ("cosine", {}),
         ("euclidean", {}),
+        ("mahalanobis", {"VI": 1}),
         ("minkowski", {"p": 3}),
         ("minkowski", {"p": 1.4}),
         ("seuclidean", {"V": 1}),
@@ -50,6 +51,7 @@ def test_1d_dist_err(funcname, kw, et, u, v):
         ("correlation", {}),
         ("cosine", {}),
         ("euclidean", {}),
+        ("mahalanobis", {}),
         ("minkowski", {"p": 3}),
         ("minkowski", {"p": 1.4}),
         ("seuclidean", {}),
@@ -82,7 +84,9 @@ def test_1d_dist(funcname, kw, seed, size, chunks):
     sp_func = getattr(spdist, funcname)
     da_func = getattr(dask_distance, funcname)
 
-    if funcname == "seuclidean":
+    if funcname == "mahalanobis":
+        kw["VI"] = 2 * np.random.random((size, size)) - 1
+    elif funcname == "seuclidean":
         kw["V"] = 2 * np.random.random((size,)) - 1
     elif funcname == "wminkowski":
         kw["w"] = 2 * np.random.random((size,)) - 1


### PR DESCRIPTION
Partially addresses issue ( https://github.com/jakirkham/dask-distance/issues/54 ).

Implements a Dask array function for computing the Mahalanobis distance between two 1-D arrays. Also tests it by comparing to the SciPy implementation of the same name.