### PR TITLE
Fix seuclidean's docstring equation

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -408,7 +408,9 @@ def seuclidean(u, v, V):
 
     .. math::
 
-       \sqrt{\sum_{i} \left( \\frac{u_{i}^{2} - v_{i}^{2}}{V_{i}} \\right)}
+       \sqrt{\sum_{i} \left(
+           \\frac{\left( u_{i} - v_{i} \\right)^{2}}{V_{i}}
+       \\right)}
 
     Args:
         u:           1-D array or collection of 1-D arrays


### PR DESCRIPTION
Incorrectly showed terms being squared before their difference was taken. This corrects that so as to take their difference and then square it.