### PR TITLE
Fix pdist selection bug

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -129,7 +129,7 @@ def pdist(X, metric="euclidean", **kwargs):
     result = dask.array.triu(result, 1)
 
     indices = _compat._indices(result.shape, chunks=result.chunks)
-    result = result[indices[1] > indices[0]]
+    result = _compat._ravel(result)[_compat._ravel(indices[1] > indices[0])]
 
     return result
 

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -121,7 +121,7 @@ def test_1d_dist(funcname, kw, seed, size, chunks):
 )
 @pytest.mark.parametrize(
     "u_shape, u_chunks, v_shape, v_chunks", [
-        ((2, 10), (1, 5), (3, 10), (1, 5)),
+        ((7, 6), (2, 2), (3, 6), (2, 2)),
     ]
 )
 def test_2d_cdist(metric, kw, seed, u_shape, u_chunks, v_shape, v_chunks):
@@ -163,7 +163,7 @@ def test_2d_cdist(metric, kw, seed, u_shape, u_chunks, v_shape, v_chunks):
 )
 @pytest.mark.parametrize(
     "u_shape, u_chunks", [
-        ((3, 10), (1, 5)),
+        ((7, 6), (2, 3)),
     ]
 )
 def test_2d_pdist(metric, kw, seed, u_shape, u_chunks):


### PR DESCRIPTION
Explores some non-trivial chunk sizes for `cdist` and `pdist`. These chunk sizes demonstrated a bug in `pdist` w.r.t. result selection. Also provides a fix for `pdist` by flattening the data and mask before selecting out the unique results.