### PR TITLE
Add atop-based ravel

### DIFF
--- a/dask_distance/_compat.py
+++ b/dask_distance/_compat.py
@@ -89,3 +89,18 @@ def _indices(dimensions, dtype=int, chunks=None):
         )
 
     return grid
+
+
+def _ravel(a):
+    a = _asarray(a)
+
+    r = dask.array.atop(
+        numpy.ravel, (a.ndim + 1,),
+        a, tuple(range(0, a.ndim)),
+        dtype=a.dtype,
+        new_axes={(a.ndim + 1): a.size},
+        adjust_chunks={0: int(numpy.prod([c[0] for c in a.chunks]))},
+        concatenate=True
+    )
+
+    return r

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -87,3 +87,30 @@ def test_indicies():
     darr = dask_distance._compat._indices((2, 3), chunks=(1, 2))
     nparr = np.indices((2, 3))
     dau.assert_eq(darr, nparr)
+
+
+@pytest.mark.parametrize(
+    "shape, dtype, chunks",
+    [
+        ((10, 11, 12), int, (3, 5, 5)),
+        ((10, 11, 12), float, (3, 5, 5)),
+        ((10, 11, 12), float, (3, 2, 2)),
+        ((20, 17, 31), float, (6, 5, 10)),
+    ]
+)
+@pytest.mark.parametrize(
+    "seed",
+    [
+        153,
+    ]
+)
+def test_ravel(shape, dtype, chunks, seed):
+    np.random.random(seed)
+
+    a = np.random.randint(0, 10, shape).astype(dtype)
+    d = da.from_array(a, chunks=chunks)
+
+    r_a = np.ravel(a)
+    r_d = dask_distance._compat._ravel(d)
+
+    dau.assert_eq(r_d, r_a)


### PR DESCRIPTION
As we want to maintain compatibility with Dask 0.13.0 (for Python 3.4 support using the conda-forge stack)* and the `ravel` implementation in that version is a bit restrictive in terms of chunking, this implements `ravel` using `atop` and NumPy's own `ravel`. Not only does this workaround the chunking constraints that Dask 0.13.0's `ravel` runs into, this `atop`-based implementation appears to go faster than the Dask 0.15.3's (latest) `ravel` implementation. So is useful not just for compatibility reasons, but performance reasons as well.

\* - Note that with noarch Python packages in conda-forge, it may be possible to relax this constraint.