### PR TITLE
Fix ravel chunking 

### DIFF
--- a/dask_distance/_compat.py
+++ b/dask_distance/_compat.py
@@ -94,13 +94,14 @@ def _indices(dimensions, dtype=int, chunks=None):
 def _ravel(a):
     a = _asarray(a)
 
+    a = a.rechunk((a.ndim - 1) * (1,) + (a.shape[-1],))
+
     r = dask.array.atop(
         numpy.ravel, (a.ndim + 1,),
         a, tuple(range(0, a.ndim)),
         dtype=a.dtype,
         new_axes={(a.ndim + 1): a.size},
-        adjust_chunks={(a.ndim + 1): int(numpy.prod([c[0] for c in a.chunks]))},
-        concatenate=True
+        adjust_chunks={(a.ndim + 1): a.chunks[-1]}
     )
 
     return r

--- a/dask_distance/_compat.py
+++ b/dask_distance/_compat.py
@@ -99,7 +99,7 @@ def _ravel(a):
         a, tuple(range(0, a.ndim)),
         dtype=a.dtype,
         new_axes={(a.ndim + 1): a.size},
-        adjust_chunks={0: int(numpy.prod([c[0] for c in a.chunks]))},
+        adjust_chunks={(a.ndim + 1): int(numpy.prod([c[0] for c in a.chunks]))},
         concatenate=True
     )
 


### PR DESCRIPTION
Drop use of `concatenate` as it is drawing all chunks into memory. Rechunk `a` to make the `ravel` operation trivial. Fix chunk adjustment for the last axis.

Note: This ends up being slower than `ravel` that is available in newer versions of Dask.