### PR TITLE
Rechunk fallback for ravel

### DIFF
--- a/dask_distance/_compat.py
+++ b/dask_distance/_compat.py
@@ -94,14 +94,11 @@ def _indices(dimensions, dtype=int, chunks=None):
 def _ravel(a):
     a = _asarray(a)
 
-    a = a.rechunk((a.ndim - 1) * (1,) + (a.shape[-1],))
-
-    r = dask.array.atop(
-        numpy.ravel, (a.ndim + 1,),
-        a, tuple(range(0, a.ndim)),
-        dtype=a.dtype,
-        new_axes={(a.ndim + 1): a.size},
-        adjust_chunks={(a.ndim + 1): a.chunks[-1]}
-    )
+    r = a
+    try:
+        r = r.ravel()
+    except ValueError:
+        # Fallback for Dask pre-0.14.1.
+        r = r.rechunk(r.chunks[:1] + r.shape[1:]).ravel()
 
     return r


### PR DESCRIPTION
It appears to just be faster to `rechunk` before using `ravel` on old Dask versions (pre-0.14.1) by roughly an order of magnitude. Newer Dask versions perform best just using the inbuilt `ravel`. So instead of trying to achieve this functionality with `atop`, just use `ravel`. If plain `ravel` cannot do the job (Dask pre-0.14.1), then fallback to running `rechunk` and `ravel` afterwards.