### PR TITLE
In `cdist`, use `_asarray` only for custom metrics

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -65,11 +65,11 @@ def cdist(XA, XB, metric="euclidean", **kwargs):
         "yule": yule,
     }
 
-    XA = _compat._asarray(XA)
-    XB = _compat._asarray(XB)
-
     result = None
     if callable(metric):
+        XA = _compat._asarray(XA)
+        XB = _compat._asarray(XB)
+
         XA_bc, XB_bc = _utils._broadcast_uv(XA, XB)
 
         XA_bc = XA_bc.rechunk(XA_bc.chunks[:-1] + ((XA_bc.shape[-1],),))


### PR DESCRIPTION
For all metrics that we provide, we already make sure that array arguments are converted to Dask Arrays. So there is no need to do this conversion beforehand unless we are using a custom metric where this might not have been done.