### PR TITLE
Fix a typo in `mahalanobis`' docstring

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -375,7 +375,7 @@ def mahalanobis(u, v, VI):
     Args:
         u:           1-D array or collection of 1-D arrays
         v:           1-D array or collection of 1-D arrays
-        V:           Inverse of the covariance matrix
+        VI:          Inverse of the covariance matrix
 
     Returns:
         float:       Mahalanobis distance


### PR DESCRIPTION
The `mahalanobis` function does not take a `V` argument, but a `VI` argument. Hence we tweak it to take `VI`.