### PR TITLE
Document `cdist`'s/`pdist`'s keyword arguments V, VI, and w

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -138,6 +138,7 @@ def pdist(X, metric="euclidean", **kwargs):
                     (default: estimated from X)
         VI:         Inverse of the covariance matrix for mahalanobis only
                     (default: estimated from X)
+        w:          1-D array of weights for wminkowski only (required)
 
     Returns:
         array:      condensed distance between each pair

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -135,6 +135,8 @@ def pdist(X, metric="euclidean", **kwargs):
         p:          p-norm for minkowski only (default: 2)
         V:          1-D array of variances for seuclidean only
                     (default: estimated from X)
+        VI:         Inverse of the covariance matrix for mahalanobis only
+                    (default: estimated from X)
 
     Returns:
         array:      condensed distance between each pair

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -131,6 +131,8 @@ def pdist(X, metric="euclidean", **kwargs):
 
     Keyword Args:
         p:          p-norm for minkowski only (default: 2)
+        V:          1-D array of variances for seuclidean only
+                    (default: estimated from X)
 
     Returns:
         array:      condensed distance between each pair

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -36,6 +36,8 @@ def cdist(XA, XB, metric="euclidean", **kwargs):
 
     Keyword Args:
         p:          p-norm for minkowski only (default: 2)
+        V:          1-D array of variances for seuclidean only
+                    (default: estimated from XA and XB)
 
     Returns:
         array:      distance between each combination of points

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -38,6 +38,8 @@ def cdist(XA, XB, metric="euclidean", **kwargs):
         p:          p-norm for minkowski only (default: 2)
         V:          1-D array of variances for seuclidean only
                     (default: estimated from XA and XB)
+        VI:         Inverse of the covariance matrix for mahalanobis only
+                    (default: estimated from XA and XB)
 
     Returns:
         array:      distance between each combination of points

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -40,6 +40,7 @@ def cdist(XA, XB, metric="euclidean", **kwargs):
                     (default: estimated from XA and XB)
         VI:         Inverse of the covariance matrix for mahalanobis only
                     (default: estimated from XA and XB)
+        w:          1-D array of weights for wminkowski only (required)
 
     Returns:
         array:      distance between each combination of points


### PR DESCRIPTION
Missed documenting the keyword arguments `V`, `VI`, and `w` of `cdist` and `pdist` when adding the metrics `seuclidean`, `mahalanobis`, and `wminkowski` respectively in PR ( https://github.com/jakirkham/dask-distance/pull/66 ). This corrects that oversight by adding brief explanations of them to the docstring.