### PR TITLE
Fix handling of metric string in `pdist`

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -151,6 +151,12 @@ def pdist(X, metric="euclidean", **kwargs):
         other tradeoffs.
     """
 
+    if not callable(metric):
+        try:
+            metric = metric.decode("utf-8")
+        except AttributeError:
+            pass
+
     if metric == "mahalanobis":
         if "VI" not in kwargs:
             kwargs["VI"] = dask.array.linalg.inv(dask.array.cov(X.T)).T


### PR DESCRIPTION
Previously `pdist` was not handling the fact that an ASCII or other non-UTF-8 string could be provided. So the comparison to metrics was not exactly correct. This fixes that issue by converting the string to UTF-8 if possible before the comparison.