### PR TITLE
Drop rechunking of `cdist`'s result

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -91,8 +91,6 @@ def cdist(XA, XB, metric="euclidean", **kwargs):
             concatenate=True,
             metric=metric
         )
-
-        result = result.rechunk(XA.chunks[0:1] + XB.chunks[0:1])
     else:
         try:
             metric = metric.decode("utf-8")


### PR DESCRIPTION
There should be no need to rechunk `cdist`'s result to match the input arrays. After all this chunking should just fall out from the operations that we have done in `cdist`. The only way the chunks would not match is if there was some rechunking done behind the scenes. If rechunking was done behind the scenes, there probably was a reason for it and thus we should leave the result's chunks alone.

This rechunking was likely added to guarantee that `pdist`'s `triu`-based optimization strategy would work (as `triu` requires square chunks). However we have dropped the `triu`-based optimization from `pdist` in favor of slicing out the relevant pieces to keep ourselves. So there is no requirement from `pdist` to have `cdist` rechunk the result.  Further if we did readd some `triu`-based optimization to `pdist`, it would be up to `pdist` to guarantee the chunking was appropriate. So `pdist`'s former requirement should not constrain `cdist`'s result's chunks.