### PR TITLE
Use `_irange` in `pdist`

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -7,6 +7,7 @@ import dask
 import dask.array
 
 from . import _compat
+from . import _pycompat
 from . import _utils
 
 from ._version import get_versions
@@ -165,7 +166,7 @@ def pdist(X, metric="euclidean", **kwargs):
     result = cdist(X, X, metric, **kwargs)
 
     result = dask.array.concatenate([
-        result[i, i + 1:] for i in range(0, len(result) - 1)
+        result[i, i + 1:] for i in _pycompat.irange(0, len(result) - 1)
     ])
 
     return result


### PR DESCRIPTION
Was using the builtin `range` in `pdist`, however its behavior differs between Python 2 and Python 3, which makes it more likely to introduce bugs due to Python version incompatibilities. Not to mention potentially different performance profiles for the different Python versions. To fix this, use our compatible `irange`, which is iterable on Python 2 and Python 3.