### PR TITLE
Support a single point in `pdist`

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -165,9 +165,14 @@ def pdist(X, metric="euclidean", **kwargs):
 
     result = cdist(X, X, metric, **kwargs)
 
-    result = dask.array.concatenate([
+    result = [
         result[i, i + 1:] for i in _pycompat.irange(0, len(result) - 1)
-    ])
+    ]
+
+    if result:
+        result = dask.array.concatenate(result)
+    else:
+        result = dask.array.empty((0,), dtype=float, chunks=(1,))
 
     return result
 

--- a/tests/test_dask_distance.py
+++ b/tests/test_dask_distance.py
@@ -189,6 +189,7 @@ def test_2d_cdist(metric, kw, seed, u_shape, u_chunks, v_shape, v_chunks):
 )
 @pytest.mark.parametrize(
     "u_shape, u_chunks", [
+        ((1, 6), (1, 3)),
         ((7, 6), (2, 3)),
     ]
 )
@@ -197,6 +198,9 @@ def test_2d_pdist(metric, kw, seed, u_shape, u_chunks):
 
     a_u = 2 * np.random.random(u_shape) - 1
     d_u = da.from_array(a_u, chunks=u_chunks)
+
+    if u_shape[0] == 1 and metric in ["mahalanobis", "seuclidean"]:
+        pytest.skip(metric + " is not supported for 1 point.")
 
     if metric == "mahalanobis":
         if "VI" not in kw:


### PR DESCRIPTION
In the case of a single point, `pdist` should return an empty array. This is because `pdist` will not include any metric computations of a point with itself. However the code was previously throwing an error for this case instead.

Included here is a test for the single point case with `pdist` and as many metrics in SciPy that support it to isolate the failing behavior. Also included is a fix for the single point in `pdist`, which should work on Dask 0.13.0+.