### PR TITLE
Drop unneeded Dask version check from tests

### DIFF
--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -2,20 +2,14 @@
 # -*- coding: utf-8 -*-
 
 
-import distutils.version as ver
-
 import pytest
 
 import numpy as np
 
-import dask
 import dask.array as da
 import dask.array.utils as dau
 
 import dask_distance._compat
-
-
-old_dask = ver.LooseVersion(dask.__version__) <= ver.LooseVersion("0.13.0")
 
 
 @pytest.mark.parametrize("x", [


### PR DESCRIPTION
This is a holdover from testing some functions included for compatibility with older versions of Dask. Given those functions and their associated tests dropped, there is no longer a need for this check. So drop it as well.