### PR TITLE
Add `_atleast_2d`

### DIFF
--- a/dask_distance/_compat.py
+++ b/dask_distance/_compat.py
@@ -26,3 +26,33 @@ def _asarray(a):
         a = dask.array.from_array(a, a.shape)
 
     return a
+
+
+def _atleast_2d(*arys):
+    """
+    Provide at least 2-D views of the arrays.
+
+    Parameters
+    ----------
+    *arys : Dask Array
+            Arrays to make at least 2-D
+
+    Returns
+    -------
+    *res : Dask Array sequence
+    """
+
+    result = []
+    for a in arys:
+        a = _asarray(a)
+        if a.ndim == 0:
+            a = a[None, None]
+        elif a.ndim == 1:
+            a = a[None]
+
+        result.append(a)
+
+    if len(arys) == 1:
+        result = result[0]
+
+    return result

--- a/dask_distance/_utils.py
+++ b/dask_distance/_utils.py
@@ -11,15 +11,8 @@ from . import _pycompat
 
 
 def _broadcast_uv(u, v):
-    u = _compat._asarray(u)
-    v = _compat._asarray(v)
-
-    U = u
-    if U.ndim == 1:
-        U = U[None]
-    V = v
-    if V.ndim == 1:
-        V = V[None]
+    U = _compat._atleast_2d(u)
+    V = _compat._atleast_2d(v)
 
     if U.ndim != 2:
         raise ValueError("u must be a 1-D or 2-D array.")

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -32,3 +32,27 @@ def test_asarray(x):
         x = np.asarray(x)
 
     dau.assert_eq(d, x)
+
+
+@pytest.mark.parametrize("a", [
+    2,
+    np.array(2),
+    np.array([2, 3]),
+    np.array([[2], [3]]),
+    np.array([[2, 3]]),
+    np.array([[2, 3], [4, 5]]),
+    np.array([[[2, 3], [4, 5]], [[6, 9], [7, 1]]]),
+    [np.array(2), np.array([[2, 3]])],
+])
+def test_atleast_2d(a):
+    if not isinstance(a, list):
+        a = [a]
+
+    d = dask_distance._compat._atleast_2d(*a)
+
+    if not isinstance(d, list):
+        d = [d]
+
+    for d_i in d:
+        assert isinstance(d_i, da.Array)
+        assert d_i.ndim >= 2


### PR DESCRIPTION
Provides an internal copy of `atleast_2d` to the compatibility module as Dask Array will eventually support this. Also adds some tests to make sure `atleast_2d` behaves ok. Make use of `atleast_2d` to simplify `_broadcast_uv` a bit.