### PR TITLE
Set `pdist`'s default argument for known metrics

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -156,12 +156,12 @@ def pdist(X, metric="euclidean", **kwargs):
         except AttributeError:
             pass
 
-    if metric == "mahalanobis":
-        if "VI" not in kwargs:
-            kwargs["VI"] = dask.array.linalg.inv(dask.array.cov(X.T)).T
-    elif metric == "seuclidean":
-        if "V" not in kwargs:
-            kwargs["V"] = dask.array.var(X, axis=0, ddof=1)
+        if metric == "mahalanobis":
+            if "VI" not in kwargs:
+                kwargs["VI"] = dask.array.linalg.inv(dask.array.cov(X.T)).T
+        elif metric == "seuclidean":
+            if "V" not in kwargs:
+                kwargs["V"] = dask.array.var(X, axis=0, ddof=1)
 
     result = cdist(X, X, metric, **kwargs)
 


### PR DESCRIPTION
Only if the metric is one of the predefined ones, try to set the default arguments if not set. No point in checking whether the default arguments need to be set if the metric is a user-provided one as they are not relevant.