### PR TITLE
Format input array in `pdist`

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -150,6 +150,8 @@ def pdist(X, metric="euclidean", **kwargs):
         other tradeoffs.
     """
 
+    X = _compat._atleast_2d(X).astype(float)
+
     if not callable(metric):
         try:
             metric = metric.decode("utf-8")


### PR DESCRIPTION
Instead of letting `cdist` format `X` in an acceptable way, go ahead and format `X` in `pdist`. Hopefully this way similar formatting in `cdist` can be optimized out. Also this makes a better guarantee that these operations don't happen to `X` twice as might occur if `X` were treated as two separate arrays.