### PR TITLE
Add `squareform`

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -167,16 +167,7 @@ def pdist(X, metric="euclidean", **kwargs):
             if "V" not in kwargs:
                 kwargs["V"] = dask.array.var(X, axis=0, ddof=1)
 
-    result = cdist(X, X, metric, **kwargs)
-
-    result = [
-        result[i, i + 1:] for i in _pycompat.irange(0, len(result) - 1)
-    ]
-
-    if result:
-        result = dask.array.concatenate(result)
-    else:
-        result = dask.array.empty((0,), dtype=float, chunks=(1,))
+    result = squareform(cdist(X, X, metric, **kwargs), force="tovec")
 
     return result
 


### PR DESCRIPTION
Provides an implementation of SciPy's [`squareform`]( https://docs.scipy.org/doc/scipy-0.19.1/reference/generated/scipy.spatial.distance.squareform.html#scipy.spatial.distance.squareform ) from `scipy.spatial.distance` for Dask Array's of distances. Also includes some tests to make sure it is well behaved.