### PR TITLE
WIP: Recursively handle pdist's diagonal chunks

### DIFF
--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -180,9 +180,8 @@ def pdist(X, metric="euclidean", **kwargs):
 
         result_pdist_i = result_empty[i_c_0:i_c_1, i_c_0:i_c_1]
         if i_c_01 > 1:
-            X_i_c_01 = X[i_c_0:i_c_1]
             X_i_c_01 = dask.array.concatenate([
-                X_i_c_01[:i_c_01 // 2], X_i_c_01[i_c_01 // 2:]
+                X[i_c_0:i_c_0 + (i_c_01 // 2)], X[i_c_0 + (i_c_01 // 2):i_c_1]
             ])
             result_pdist_i = pdist(X_i_c_01, metric, **kwargs)
 

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -180,11 +180,11 @@ def pdist(X, metric="euclidean", **kwargs):
 
         result_pdist_i = result_empty[i_c_0:i_c_1, i_c_0:i_c_1]
         if i_c_01 > 1:
-            result_pdist_i = pdist(
-                X[i_c_0:i_c_1].rechunk({0: (i_c_01 + 1) // 2}),
-                metric,
-                **kwargs
-            )
+            X_i_c_01 = X[i_c_0:i_c_1]
+            X_i_c_01 = dask.array.concatenate([
+                X_i_c_01[:i_c_01 // 2], X_i_c_01[i_c_01 // 2:]
+            ])
+            result_pdist_i = pdist(X_i_c_01, metric, **kwargs)
 
         ir_flat = 0
         for ir, i in enumerate(_pycompat.irange(i_c_0, i_c_1)):

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -189,13 +189,9 @@ def pdist(X, metric="euclidean", **kwargs):
         for ir, i in enumerate(_pycompat.irange(i_c_0, i_c_1)):
             if (i + 1) < i_c_1:
                 ir_flat += ir
-                result.append(
-                    result_pdist_i[ir_flat:ir_flat + i_c_01]
-                )
+                result.append(result_pdist_i[ir_flat:ir_flat + i_c_01])
             if i_c_1 < result_cdist.shape[1]:
-                result.append(
-                    result_cdist[i, i_c_1:]
-                )
+                result.append(result_cdist[i, i_c_1:])
 
         i_c_0 = i_c_1
 

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -180,14 +180,25 @@ def pdist(X, metric="euclidean", **kwargs):
 
         result_pdist_i = result_empty[i_c_0:i_c_1, i_c_0:i_c_1]
         if i_c_01 > 1:
-            result_pdist_i = squareform(
-                pdist(
-                    X[i_c_0:i_c_1].rechunk({0: (i_c_01 + 1) // 2}),
-                    metric,
-                    **kwargs
-                ),
-                force="tomatrix"
+            X_i_c_01 = X[i_c_0:i_c_1]
+            result_pdist_i = pdist(
+                X_i_c_01.rechunk((i_c_01 + 1) // 2),
+                metric,
+                **kwargs
             )
+
+            result_pdist_i_chunks = sum(
+                [
+                    X_i_c_01[i:].chunks[0]
+                    for i in _pycompat.irange(1, len(X_i_c_01))
+                ],
+                tuple()
+            )
+            result_pdist_i = result_pdist_i.rechunk(
+                2 * (result_pdist_i_chunks,)
+            )
+
+            result_pdist_i = squareform(result_pdist_i, force="tomatrix")
 
         for ir, i in enumerate(_pycompat.irange(i_c_0, i_c_1)):
             if (i + 1) < i_c_1:

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -180,19 +180,18 @@ def pdist(X, metric="euclidean", **kwargs):
 
         result_pdist_i = result_empty[i_c_0:i_c_1, i_c_0:i_c_1]
         if i_c_01 > 1:
-            result_pdist_i = squareform(
-                pdist(
-                    X[i_c_0:i_c_1].rechunk({0: (i_c_01 + 1) // 2}),
-                    metric,
-                    **kwargs
-                ),
-                force="tomatrix"
+            result_pdist_i = pdist(
+                X[i_c_0:i_c_1].rechunk({0: (i_c_01 + 1) // 2}),
+                metric,
+                **kwargs
             )
 
+        ir_flat = 0
         for ir, i in enumerate(_pycompat.irange(i_c_0, i_c_1)):
             if (i + 1) < i_c_1:
+                ir_flat += ir
                 result.append(
-                    result_pdist_i[ir, ir + 1:i_c_01]
+                    result_pdist_i[ir_flat:ir_flat + i_c_01]
                 )
             if i_c_1 < result_cdist.shape[1]:
                 result.append(

--- a/dask_distance/__init__.py
+++ b/dask_distance/__init__.py
@@ -180,25 +180,14 @@ def pdist(X, metric="euclidean", **kwargs):
 
         result_pdist_i = result_empty[i_c_0:i_c_1, i_c_0:i_c_1]
         if i_c_01 > 1:
-            X_i_c_01 = X[i_c_0:i_c_1]
-            result_pdist_i = pdist(
-                X_i_c_01.rechunk((i_c_01 + 1) // 2),
-                metric,
-                **kwargs
+            result_pdist_i = squareform(
+                pdist(
+                    X[i_c_0:i_c_1].rechunk({0: (i_c_01 + 1) // 2}),
+                    metric,
+                    **kwargs
+                ),
+                force="tomatrix"
             )
-
-            result_pdist_i_chunks = sum(
-                [
-                    X_i_c_01[i:].chunks[0]
-                    for i in _pycompat.irange(1, len(X_i_c_01))
-                ],
-                tuple()
-            )
-            result_pdist_i = result_pdist_i.rechunk(
-                2 * (result_pdist_i_chunks,)
-            )
-
-            result_pdist_i = squareform(result_pdist_i, force="tomatrix")
 
         for ir, i in enumerate(_pycompat.irange(i_c_0, i_c_1)):
             if (i + 1) < i_c_1:


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/dask-distance/pull/84 ).
Fixes https://github.com/jakirkham/dask-distance/issues/92

Make use of `cdist` for computing the bulk of the results for `pdist`. However drop all duplicate chunks on the opposite side of the diagonal. Though keep all chunks on the right side of the diagonal.

As for any chunks that straddle the diagonal, recursively break them up into smaller pieces. If the pieces are on the right side of the diagonal, they are trivially handled with `cdist`. If they are on or beyond the diagonal, they are trivially dropped. If they still land on the diagonal, repeat the process by calling into `pdist` again until they are resolved one of these two ways.

Since `pdist` returns its results in vector form, the recursive portion needs to make use of `squareform` to convert them back into square matrices that can be more easily worked with. Though the results are again unraveled according to the constraints of `pdist`. So the brief restructuring with `squareform` is a mere convenience to allow recursive calls of `pdist` to proceed without issues.