### PR TITLE
Should be authors of `dask-distance` in license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017, dask-ndmeasure Developers (see AUTHORS.rst for details)
+Copyright (c) 2017, dask-distance Developers (see AUTHORS.rst for details)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Was authors `dask-ndmeasure` due to a copy-paste error. This corrects it to be `dask-distance` authors as intended.